### PR TITLE
- Put first logging instance after basicConfig call

### DIFF
--- a/nanofilt/NanoFilt.py
+++ b/nanofilt/NanoFilt.py
@@ -28,11 +28,13 @@ import pandas as pd
 import nanofilt.utils as utils
 import logging
 from math import log
+from nanofilt.version import __version__
 
 
 def main():
     args = utils.get_args()
     utils.start_logging(args.logfile)
+    logging.info('NanoFilt {} started with arguments {}'.format(__version__, args))
     try:
         if args.tailcrop:
             args.tailcrop = -args.tailcrop

--- a/nanofilt/utils.py
+++ b/nanofilt/utils.py
@@ -84,7 +84,6 @@ def get_args():
         args.GC_filter = False
     else:
         args.GC_filter = True
-    logging.info('NanoFilt {} started with arguments {}'.format(__version__, args))
     return args
 
 


### PR DESCRIPTION
closes #50

The Logging [docs ](https://docs.python.org/3/howto/logging.html#logging-to-a-file)state:
> The call to basicConfig() should come before any calls to debug(), info(), etc. Otherwise, those functions will call basicConfig() for you with the default options. As it’s intended as a one-off simple configuration facility, only the first call will actually do anything: subsequent calls are effectively no-ops.